### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/ios/documentation/index.md
+++ b/ios/documentation/index.md
@@ -6,7 +6,7 @@ The Ti.Magtek module allows for developing applications for the iDynamo and audi
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting
 started with using this module in your application.
 
 ## Using the MagTek module with iOS5+ devices


### PR DESCRIPTION
Replaced `../titanium﻿..` with `../platform﻿..` in any and all URLs of this yaml file.

https://jira.appcelerator.org/browse/MOD-2124